### PR TITLE
Fixing CI project name to krug/tinyhorse

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tiny horse
 
-[![CircleCI](https://circleci.com/gh/superherointj/tinyhorse/tree/master.svg?style=svg)](https://circleci.com/gh/superherointj/tinyhorse/tree/master)
+[![CircleCI](https://circleci.com/gh/krig/tinyhorse/tree/master.svg?style=svg)](https://circleci.com/gh/krig/tinyhorse/tree/master)
 
 !["screenshot"](https://github.com/krig/tinyhorse/raw/master/data/tinyhorse.jpg "screenshot")
 


### PR DESCRIPTION
1) I'm sorry, there was a CI mistake here. My fork's CI got imported with wrong project name. This patch changes the README.md to reflect the correct URL.

2) Can you activate CI at CircleCI? So the CI Badget is shown properly at Readme?